### PR TITLE
Remove AvailableOperationList[]=content_read default workflow.ini settings

### DIFF
--- a/settings/workflow.ini.append.php
+++ b/settings/workflow.ini.append.php
@@ -1,7 +1,7 @@
 <?php /* #?ini charset="iso-8859-1"?
 
-[OperationSettings]
-AvailableOperationList[]=content_read
+#[OperationSettings]
+#AvailableOperationList[]=content_read
 
 [EventSettings]
 ExtensionDirectories[]=ocoperatorscollection


### PR DESCRIPTION
Produce fino a 20 query non cacheabili...
Se approvi faccio un cherry pick anche sul tag 1.x (il master è a 2, per fix costruttori php)
Se non puoi approvarla discutiamone